### PR TITLE
Spelling [sued] -> [used]

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1276,7 +1276,7 @@ public class GraphDatabaseConfiguration {
             "Gremlin configuration options");
 
     public static final ConfigOption<String> GREMLIN_GRAPH = new ConfigOption<String>(GREMLIN_NS, "graph",
-            "The implementation of graph factory that will be sued by gremlin server", ConfigOption.Type.LOCAL, "com.thinkaurelius.titan.core.TitanFactory");
+            "The implementation of graph factory that will be used by gremlin server", ConfigOption.Type.LOCAL, "com.thinkaurelius.titan.core.TitanFactory");
 
     // ################ Begin Class Definition #######################
     // ###############################################################


### PR DESCRIPTION
Small spelling fix.

Changes the word [sued] to [used] in GraphDatabaseConfiguration.java
